### PR TITLE
Pass db argument to transact from transact!

### DIFF
--- a/src/clj_3df/core.cljc
+++ b/src/clj_3df/core.cljc
@@ -115,7 +115,7 @@
     {:Transact {:tx_data tx-data}}))
 
 (defn transact! [conn db tx-data]
-  (->> (transact tx-data) (json/generate-string) (stream/put! conn)))
+  (->> (transact db tx-data) (json/generate-string) (stream/put! conn)))
 
 (comment
   (def conn @(http/websocket-client "ws://127.0.0.1:6262"))


### PR DESCRIPTION
Fixes "Wrong number of args (1) passed to: core/transact" when calling `transact!` from the examples in the comment at the bottom of `core.clj`.

I'm really into what you're doing here and elsewhere. Thanks for sharing it.