### PR TITLE
Update attribute encoding, add create-input

### DIFF
--- a/src/clj_3df/core.cljc
+++ b/src/clj_3df/core.cljc
@@ -114,6 +114,14 @@
     {:name   name
      :source source}}])
 
+(defmulti create-input class)
+
+(defmethod create-input clojure.lang.Keyword [attr]
+  [{:CreateInput {:name (str attr)}}])
+
+(defmethod create-input clj_3df.core.DB [db]
+  (reduce-kv (fn [acc k v] (conj acc {:CreateInput {:name (str k)}})) [] (-schema db)))
+
 (defn- reverse-ref [attr]
   (if (reverse-ref? attr)
     (keyword (namespace attr) (subs (name attr) 1))

--- a/src/clj_3df/core.cljc
+++ b/src/clj_3df/core.cljc
@@ -30,18 +30,18 @@
 (defprotocol IDB
   (-schema [db])
   (-attrs-by [db property])
-  (-attr->int [db attr])
-  (-int->attr [db i]))
+  (-attr->str [db attr])
+  (-str->attr [db str]))
 
-(defrecord DB [schema rschema attr->int int->attr next-tx]
+(defrecord DB [schema rschema attr->str str->attr next-tx]
   IDB
   (-schema [db] (.-schema db))
   (-attrs-by [db property] ((.-rschema db) property))
-  (-attr->int [db attr]
-    (if-let [[k v] (find attr->int attr)]
+  (-attr->str [db attr]
+    (if-let [[k v] (find attr->str attr)]
       v
       (throw (ex-info "Unknown attribute." {:attr attr}))))
-  (-int->attr [db i] (int->attr i)))
+  (-str->attr [db str] (str->attr str)))
 
 (defn- ^Boolean is-attr? [^DB db attr property] (contains? (-attrs-by db property) attr))
 (defn- ^Boolean multival? [^DB db attr] (is-attr? db attr :db.cardinality/many))
@@ -74,9 +74,9 @@
     {} schema))
 
 (defn create-db [schema]
-  (let [attr->int (zipmap (keys schema) (iterate (partial + 100) 100))
-        int->attr (set/map-invert attr->int)]
-    (->DB schema (rschema schema) attr->int int->attr 0)))
+  (let [attr->str (into {} (map (juxt identity str) (keys schema)))
+        str->attr (set/map-invert attr->str)]
+    (->DB schema (rschema schema) attr->str str->attr 0)))
 
 (defn interest [name]
   [{:Interest {:name name}}])
@@ -88,7 +88,7 @@
     (concat
      [{:Register
        {:publish [name]
-        :rules   (->> (conj rules top-rule) (encode/encode-rules (partial -attr->int db)))}}]
+        :rules   (->> (conj rules top-rule) (encode/encode-rules (partial -attr->str db)))}}]
      ;; @TODO split this off
      (interest name))))
 
@@ -101,11 +101,11 @@
          compiled-rules (if (empty? rules)
                           []
                           (compiler/compile-rules rules))]
-     (concat 
+     (concat
       [{:Register
         {:publish [name]
          :rules   (->> (conj compiled-rules top-rule)
-                       (encode/encode-rules (partial -attr->int db)))}}]
+                       (encode/encode-rules (partial -attr->str db)))}}]
       ;; @TODO split this off
       (interest name)))))
 
@@ -158,10 +158,10 @@
                                     :Transact
                                     :tx_data
                                     (into tx-data))
-                               
+
                                (sequential? datum)
                                (let [[op e a v] datum]
-                                 (conj tx-data [(op->diff op) e (-attr->int db a) (wrap-type a v)]))))
+                                 (conj tx-data [(op->diff op) e (-attr->str db a) (wrap-type a v)]))))
                            [] tx-data)]
      [{:Transact {:tx tx :tx_data tx-data}}])))
 

--- a/src/clj_3df/encode.cljc
+++ b/src/clj_3df/encode.cljc
@@ -8,30 +8,30 @@
 (def encode-symbol (memoize (fn [sym] #?(:clj  (clojure.lang.RT/nextID)
                                          :cljs (swap! nextID inc)))))
 
-(defn encode-plan [attr->int plan]
+(defn encode-plan [attr->str plan]
   (cond
     (symbol? plan)      (encode-symbol plan)
-    (keyword? plan)     (attr->int plan)
-    (sequential? plan)  (mapv (partial encode-plan attr->int) plan)
-    (associative? plan) (reduce-kv (fn [m k v] (assoc m k (encode-plan attr->int v))) {} plan)
+    (keyword? plan)     (attr->str plan)
+    (sequential? plan)  (mapv (partial encode-plan attr->str) plan)
+    (associative? plan) (reduce-kv (fn [m k v] (assoc m k (encode-plan attr->str v))) {} plan)
     (nil? plan)         (throw (ex-info "Plan contain's nils."
                                         {:causes #{:contains-nil}}))
     :else               plan))
 
-(defn encode-rule [attr->int rule]
+(defn encode-rule [attr->str rule]
   (let [{:keys [name plan]} rule]
     {:name name
-     :plan (encode-plan attr->int plan)}))
+     :plan (encode-plan attr->str plan)}))
 
-(defn encode-rules [attr->int rules]
-  (mapv (partial encode-rule attr->int) rules))
+(defn encode-rules [attr->str rules]
+  (mapv (partial encode-rule attr->str) rules))
 
 (comment
   (encode-plan {} [])
   (encode-plan {} '?name)
-  (encode-plan {:name 100} '{:MatchA [?e :name ?n]})
-  (encode-plan {:name 200} '{:Join [?n {:MatchA [?e1 :name ?n]} {:MatchA [?e2 :name ?n]}]})
-  (encode-plan {:name 300} '{:Join [?n {:MatchA [?e1 :name ?n]} {:MatchA [?e2 :name ?n]}]})
-  (encode-plan {:name 400} '{:Project
+  (encode-plan {:name ":name"} '{:MatchA [?e :name ?n]})
+  (encode-plan {:name ":name"} '{:Join [?n {:MatchA [?e1 :name ?n]} {:MatchA [?e2 :name ?n]}]})
+  (encode-plan {:name ":name"} '{:Join [?n {:MatchA [?e1 :name ?n]} {:MatchA [?e2 :name ?n]}]})
+  (encode-plan {:name ":name"} '{:Project
                              [[?e1 ?n ?e2] {:Join [?n {:MatchA [?e1 :name ?n]} {:MatchA [?e2 :name ?n]}]}]})
   )

--- a/src/clj_3df/encode.cljc
+++ b/src/clj_3df/encode.cljc
@@ -8,23 +8,23 @@
 (def encode-symbol (memoize (fn [sym] #?(:clj  (clojure.lang.RT/nextID)
                                          :cljs (swap! nextID inc)))))
 
-(defn encode-plan [attr->str plan]
+(defn encode-plan [attribute->id plan]
   (cond
     (symbol? plan)      (encode-symbol plan)
-    (keyword? plan)     (attr->str plan)
-    (sequential? plan)  (mapv (partial encode-plan attr->str) plan)
-    (associative? plan) (reduce-kv (fn [m k v] (assoc m k (encode-plan attr->str v))) {} plan)
+    (keyword? plan)     (attribute->id plan)
+    (sequential? plan)  (mapv (partial encode-plan attribute->id) plan)
+    (associative? plan) (reduce-kv (fn [m k v] (assoc m k (encode-plan attribute->id v))) {} plan)
     (nil? plan)         (throw (ex-info "Plan contain's nils."
                                         {:causes #{:contains-nil}}))
     :else               plan))
 
-(defn encode-rule [attr->str rule]
+(defn encode-rule [attribute->id rule]
   (let [{:keys [name plan]} rule]
     {:name name
-     :plan (encode-plan attr->str plan)}))
+     :plan (encode-plan attribute->id plan)}))
 
-(defn encode-rules [attr->str rules]
-  (mapv (partial encode-rule attr->str) rules))
+(defn encode-rules [attribute->id rules]
+  (mapv (partial encode-rule attribute->id) rules))
 
 (comment
   (encode-plan {} [])


### PR DESCRIPTION
Move from integer encoded attrs to simply using the str of the keyword. Create-input can either be used with a db or with single attrs.