### PR TITLE
Create Input cljs fix, compiler aggregate key symbols fix

### DIFF
--- a/src/clj_3df/core.cljc
+++ b/src/clj_3df/core.cljc
@@ -115,10 +115,13 @@
     {:name   name
      :source source}}])
 
-(defmulti create-input class)
+(defmulti create-input type)
 
-(defmethod create-input clojure.lang.Keyword [attr]
-  [{:CreateInput {:name (str attr)}}])
+#?(:cljs (defmethod create-input cljs.core/Keyword [attr]
+          [{:CreateInput {:name (str attr)}}]))
+
+#?(:clj  (defmethod create-input clojure.lang.Keyword [attr]
+          [{:CreateInput {:name (str attr)}}]))
 
 (defmethod create-input clj_3df.core.DB [db]
   (reduce-kv (fn [acc k v] (conj acc {:CreateInput {:name (str k)}})) [] (-schema db)))

--- a/src/clj_3df/core.cljc
+++ b/src/clj_3df/core.cljc
@@ -115,15 +115,10 @@
     {:name   name
      :source source}}])
 
-(defmulti create-input type)
+(defn create-input [attr]
+  [{:CreateInput {:name (str attr)}}])
 
-#?(:cljs (defmethod create-input cljs.core/Keyword [attr]
-          [{:CreateInput {:name (str attr)}}]))
-
-#?(:clj  (defmethod create-input clojure.lang.Keyword [attr]
-          [{:CreateInput {:name (str attr)}}]))
-
-(defmethod create-input clj_3df.core.DB [db]
+(defn create-db-inputs [^DB db]
   (reduce-kv (fn [acc k v] (conj acc {:CreateInput {:name (str k)}})) [] (-schema db)))
 
 (defn- reverse-ref [attr]


### PR DESCRIPTION
The last argument in the aggregate compilation is a vec of keys the aggregate should be grouped by. We need to remove the symbol that is used in the aggregation fn from the binding to extract the grouping keys. As one may be grouping by the same key one is aggregating (even though that does not result in really meaningful results) we need to only remove one symbol, s.t. we still group by the aggregation fns symbol. 