### PR TITLE
Compiler fix aggregations and functions expressions

### DIFF
--- a/src/clj_3df/compiler.cljc
+++ b/src/clj_3df/compiler.cljc
@@ -77,7 +77,7 @@
                      :string string?
                      :bool   boolean?))
 (s/def ::predicate '#{<= < > >= = not=})
-(s/def ::aggregation-fn '#{min max count})
+(s/def ::aggregation-fn '#{min max count median sum avg variance})
 (s/def ::function '#{interval})
 (s/def ::fn-arg (s/or :var ::variable :const ::value))
 

--- a/test/clj_3df/compiler_test.cljc
+++ b/test/clj_3df/compiler_test.cljc
@@ -471,11 +471,22 @@
              (compile-query query))))))
 
 (deftest test-functions
-  (let [query '[:find ?e ?t
-                :where
-                [?e :event/time ?t] [(interval ?t) ?t]]]
-    (is (= '{:Transform
-             [[?t]
-              "interval"
-              {:MatchA [?e :event/time ?t]}]}
-           (compile-query query)))))
+  (testing "fn"
+    (let [query '[:find ?e ?t
+                  :where
+                  [?e :event/time ?t] [(interval ?t) ?t]]]
+      (is (= '{:Transform
+               [[?t]
+                {:MatchA [?e :event/time ?t]}
+                "INTERVAL"]}
+             (compile-query query)))))
+  (testing "fn-pred"
+    (let [query '[:find ?e ?t
+                  :in ?cutoff
+                  :where
+                  [?e :event/time ?t][(> ?t ?cutoff)][(interval ?t) ?t]]]
+      (is (= '{:Transform
+               [[?t]
+                {:Filter [[?t ?cutoff] "GT" {:MatchA [?e :event/time ?t]}]}
+                "INTERVAL"]}
+             (compile-query query))))))


### PR DESCRIPTION
I left the `args` in the defrecord of the aggregation as we might need it in the future for multiple aggregations in the same :find clause.
I just realised that that could also be done via comparing the variables :Aggregation has been called with and the key symbols.