### PR TITLE
Extend function expressions to take constant bindings

### DIFF
--- a/src/clj_3df/compiler.cljc
+++ b/src/clj_3df/compiler.cljc
@@ -88,7 +88,7 @@
 
 (s/def ::predicate '#{<= < > >= = not=})
 (s/def ::aggregation-fn '#{min max count median sum avg variance})
-(s/def ::function '#{interval})
+(s/def ::function '#{truncate})
 (s/def ::fn-arg (s/or :var ::variable :const ::value))
 
 ;; PARSING
@@ -475,7 +475,7 @@
               (->Predicate '> '[?age] nil {}))
 
   (unify-with [(->Predicate '> '[?t ?cutoff] (->Relation ::hasattr '[?e :time ?t] '[?e ?t]) {})]
-              (->FnExpr :interval '[?t] '[?t] nil))
+              (->FnExpr :truncate '[?t] '[?t] nil))
 
   (unify-with [(->Relation ::hasattr '[?e :age ?age] '[?e ?age])]
               (->Negation [(->Relation ::filter '[?e :age [:number 18]] '[?e])] []))
@@ -586,7 +586,7 @@
 
   (compile-query '[:find ?unbound :where [?bound :name "Dipper"]])
 
-  (compile-query '[:find ?n ?e :where [?e :name ?n]])
+  (compile-query '[:find ?n ?p :where [?e :name ?n][(truncate ?n :hour) ?p]])
 
   (compile-query '[:find (count ?e) :where [?e :name "Dipper"]])
 

--- a/test/clj_3df/compiler_test.cljc
+++ b/test/clj_3df/compiler_test.cljc
@@ -474,28 +474,29 @@
   (testing "fn-in-place"
     (let [query '[:find ?e ?t
                   :where
-                  [?e :event/time ?t] [(interval ?t) ?t]]]
+                  [?e :event/time ?t] [(truncate ?t) ?t]]]
       (is (thrown? clojure.lang.ExceptionInfo (compile-query query)))))
   (testing "fn"
       (let [query '[:find ?e ?h
                     :where
-                    [?e :event/time ?t] [(interval ?t) ?h]]]
+                    [?e :event/time ?t] [(truncate ?t) ?h]]]
         (is (= '{:Project
                  [[?e ?h]
                   {:Transform
-                   [[?t] ?h {:MatchA [?e :event/time ?t]}]}]}))))
+                   [[?t] ?h {:MatchA [?e :event/time ?t]} "TRUNCATE" {}]}]}
+               (compile-query query)))))
   (testing "fn-pred"
     (let [query '[:find ?e ?h
                   :in ?cutoff
                   :where
-                  [?e :event/time ?t][(> ?t ?cutoff)][(interval ?t) ?h]]]
+                  [?e :event/time ?t][(> ?t ?cutoff)][(truncate ?t) ?h]]]
       (is (= '{:Project
                [[?e ?h]
                 {:Transform
                  [[?t]
                   ?h
                   {:Filter [[?t ?cutoff] "GT" {:MatchA [?e :event/time ?t]} {}]}
-                  "INTERVAL"]}]}
+                  "TRUNCATE" {}]}]}
              (compile-query query))))))
 
 (deftest test-name-expressions


### PR DESCRIPTION
- Add keyword as possible encoded constant binding –> will internally be converted to a string 