### PR TITLE
Multiple aggregations

### DIFF
--- a/src/clj_3df/compiler.cljc
+++ b/src/clj_3df/compiler.cljc
@@ -87,7 +87,7 @@
                      :bool    boolean?))
 
 (s/def ::predicate '#{<= < > >= = not=})
-(s/def ::aggregation-fn '#{min max count median sum avg})
+(s/def ::aggregation-fn '#{min max count median sum avg variance})
 (s/def ::function '#{truncate concat})
 (s/def ::fn-arg (s/or :var ::variable :const ::value))
 

--- a/src/clj_3df/compiler.cljc
+++ b/src/clj_3df/compiler.cljc
@@ -583,7 +583,7 @@
         unified     (->> (:where ir) (reduce normalize []) unify-context extract-binding)
         find-syms   (extract-find-symbols (:find ir))
         key-syms    (extract-key-symbols (:find ir))
-        projection  (->Projection unified (reduce-kv (fn [acc k v] (conj acc (first v))) [] (group-by name find-syms)))
+        projection  (->Projection unified (distinct find-syms))
         aggregation (if-let [[agg & remaining :as all] (-> (:find ir) extract-aggregations seq)]
                       (if remaining
                         (->AggregationMulti (map :aggregation-fn all) (mapcat :vars all) key-syms projection find-syms)

--- a/src/clj_3df/compiler.cljc
+++ b/src/clj_3df/compiler.cljc
@@ -87,8 +87,8 @@
                      :bool    boolean?))
 
 (s/def ::predicate '#{<= < > >= = not=})
-(s/def ::aggregation-fn '#{min max count median sum avg variance})
-(s/def ::function '#{truncate})
+(s/def ::aggregation-fn '#{min max count median sum avg})
+(s/def ::function '#{truncate concat})
 (s/def ::fn-arg (s/or :var ::variable :const ::value))
 
 ;; PARSING

--- a/src/clj_3df/compiler.cljc
+++ b/src/clj_3df/compiler.cljc
@@ -228,9 +228,20 @@
   (plan [this]
     (let [symbols (bound-symbols this)]
       (if (binds-all? binding symbols)
-        {:Aggregate [symbols (plan binding) (str/upper-case (name fn-symbol)) key-symbols]}
+        {:Aggregate [symbols (plan binding) (str/upper-case (name fn-symbol)) key-symbols args]}
         (if debug?
           {:Aggregate [args :_ (str/upper-case (name fn-symbol)) symbols]}
+          (throw (ex-info "Aggregation on unbound symbols." {:binding (debug-plan this)})))))))
+
+(defrecord AggregationMulti [fn-symbols args key-symbols binding symbols]
+  IBinding
+  (bound-symbols [this] symbols)
+  (plan [this]
+    (let [symbols (bound-symbols this)]
+      (if (binds-all? binding symbols)
+        {:AggregateMulti [symbols (plan binding) (map (comp str/upper-case name) fn-symbols) key-symbols args]}
+        (if debug?
+          {:AggregateMulti [args :_ (map (comp str/upper-case name) fn-symbols) symbols]}
           (throw (ex-info "Aggregation on unbound symbols." {:binding (debug-plan this)})))))))
 
 (defrecord Projection [binding symbols]
@@ -572,10 +583,10 @@
         unified     (->> (:where ir) (reduce normalize []) unify-context extract-binding)
         find-syms   (extract-find-symbols (:find ir))
         key-syms    (extract-key-symbols (:find ir))
-        projection  (->Projection unified find-syms)
+        projection  (->Projection unified (reduce-kv (fn [acc k v] (conj acc (first v))) [] (group-by name find-syms)))
         aggregation (if-let [[agg & remaining :as all] (-> (:find ir) extract-aggregations seq)]
                       (if remaining
-                        (throw (ex-info "Only single aggregations in the :find clause are supported for now" {}))
+                        (->AggregationMulti (map :aggregation-fn all) (mapcat :vars all) key-syms projection find-syms)
                         (->Aggregation (:aggregation-fn agg) (:vars agg) key-syms projection find-syms))
                       projection)
         ]

--- a/test/clj_3df/compiler_test.cljc
+++ b/test/clj_3df/compiler_test.cljc
@@ -467,7 +467,7 @@
   (testing "min"
     (let [query '[:find ?user (min ?age)
                   :where [?user :age ?age]]]
-      (is (= '{:Aggregate [[?user ?age] {:MatchA [?user :age ?age]} "MIN" [?user]]}
+      (is (= '{:Aggregate [[?user ?age] {:MatchA [?user :age ?age]} "MIN" [?user] [?age]]}
              (compile-query query))))))
 
 (deftest test-functions


### PR DESCRIPTION
- Add record for multiple aggregations
- Aggregations now pass the argument symbols as a vector, also single aggregations as they are needed to reorder the key – value syms after the aggregation
- Projection now only gets a deduped version of the :find-syms. Prior led to overflow panics in the backends `tuples_by_symbols()`. Projection would try to project nested plans bindings onto symbols in the find clause which have a potential higher multiplicity due to several aggregations. So the nested bindings were smaller in number than Projections variables.  
- Add fn_exp concat