### PR TITLE
Add datomics with functionality

### DIFF
--- a/src/clj_3df/compiler.cljc
+++ b/src/clj_3df/compiler.cljc
@@ -42,11 +42,13 @@
 ;; GRAMMAR
 
 (s/def ::query (s/keys :req-un [::find ::where]
-                       :opt-un [::in]))
+                       :opt-un [::in ::with]))
 
 (s/def ::find (s/alt ::find-rel ::find-rel))
 (s/def ::find-rel (s/+ ::find-elem))
 (s/def ::find-elem (s/or :var ::variable :aggregate ::aggregate))
+
+(s/def ::with (s/+ ::variable))
 
 (s/def ::in (s/+ ::variable))
 

--- a/test/clj_3df/compiler_test.cljc
+++ b/test/clj_3df/compiler_test.cljc
@@ -467,7 +467,7 @@
   (testing "min"
     (let [query '[:find ?user (min ?age)
                   :where [?user :age ?age]]]
-      (is (= '{:Aggregate [[?user ?age] {:MatchA [?user :age ?age]} "MIN" [?user] [?age]]}
+      (is (= '{:Aggregate [[?user ?age] {:MatchA [?user :age ?age]} ["MIN"] [?user] [?age] []]}
              (compile-query query))))))
 
 (deftest test-functions

--- a/test/clj_3df/compiler_test.cljc
+++ b/test/clj_3df/compiler_test.cljc
@@ -511,3 +511,16 @@
                   :where (local-rule ?x ?y)]]
       (is (= '{:RuleExpr [[?x ?y] "local-rule"]}
              (compile-query query))))))
+
+(deftest with-clause
+  (testing "correct with-clause"
+    (let [query '[:find (sum ?amount) 
+                  :with ?e
+                  :where [?e :amount ?amount]]]
+      (is (= '{:Aggregate [[?amount] {:Project [[?amount ?e] {:MatchA [?e :amount ?amount]}]} ["SUM"] [] [?amount] [?e]]}
+             (compile-query query))))
+    (testing "Duplicated find- and with-symbols"
+      (let [query '[:find ?e (sum ?amount) 
+                    :with ?e
+                    :where [?e :amount ?amount]]]
+        (is (thrown? clojure.lang.ExceptionInfo (compile-query query)))))))


### PR DESCRIPTION
- Aggregations now also pass the specified symbols from the `:with`-clause
- The Projection record will ensure, that there are no duplicated symbols in the `:find`- and `:with`-clause and correctly project