### PR TITLE
Fix unwrap of results

### DIFF
--- a/src/clj_3df/core.cljc
+++ b/src/clj_3df/core.cljc
@@ -187,10 +187,9 @@
 
 (defn parse-result
   [result]
-  (let [unwrap-type  (fn [boxed] (second (first boxed)))
-        unwrap-tuple (fn [[tuple time diff :as result-diff]]
+  (let [unwrap-tuple (fn [[tuple time diff :as result-diff]]
                        (if (vector? tuple)
-                         [(mapv unwrap-type tuple) time diff]
+                         [tuple time diff]
                          result-diff))
         xf-batch     (map unwrap-tuple)]
     (let [[query_name results] (parse-json result)]


### PR DESCRIPTION
For most of the types the server sends them already unpacked so we need no unpacking. The rest will stay annotated. 