### PR TITLE
fix `unlisten-query!`

### DIFF
--- a/src/clj_3df/core.cljc
+++ b/src/clj_3df/core.cljc
@@ -232,7 +232,7 @@
   "Unregisters a callback that was previously registered via
   `listen-query!`."
   [^Connection conn query key]
-  (swap! (.-query-listeners conn) update-in query dissoc key))
+  (swap! (.-query-listeners conn) update query dissoc key))
 
 #?(:clj (defn create-conn!
           [url]


### PR DESCRIPTION
Current `unlisten-query!` uses `update-in` which will treat query-name as update path, leading to unwanted behaviour like
`{\l {\o {\a {\n {\s nil}}}}}`.
This fix is tested in a REPL.